### PR TITLE
Fix error message:

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 let url = process.env.MONGODB_URI || 'mongodb://localhost/legoTrader';
-mongoose.connect(url);
+mongoose.connect(url, { useMongoClient: true });
 
 let db = mongoose.connection;
 


### PR DESCRIPTION
DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`